### PR TITLE
Clean LaTeX generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ By default pdflatex will be used. Replace <engine> with your engine of choice e.
 ```
 let g:latex_engine="<engine>"
 ```
+
+### Cleaning generated files
+
+By default we don't remove LaTeX generated files: .log, .out and .aux file. To remove them automatically, set to 1
+
+```
+let g:latex_preview_clean = 1
+```

--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -35,6 +35,9 @@ endfunction
 function! s:OpenPdf(pdf_viewer)
     execute "silent !". g:latex_engine. " % &>/dev/null && pkill -HUP mupdf &> /dev/null"
     execute "silent !" .a:pdf_viewer. " %:r.pdf &> /dev/null &"
+    if exists('g:latex_preview_clean') && g:latex_preview_clean
+        execute "silent ! rm *.aux *.out *.log"
+    endif
     redraw!
 endfunction
 


### PR DESCRIPTION
Just added an option to clean .log, .aux and .out files generated by LaTeX (so we keep only the .pdf file). For people who likes to keep their directories clean.

Shouldn't change anything if the option isn't enabled.